### PR TITLE
Fix build instructions for musl

### DIFF
--- a/src/content/docs/cheerp/00-installation/10-source/01-linux.md
+++ b/src/content/docs/cheerp/00-installation/10-source/01-linux.md
@@ -56,14 +56,14 @@ cd ..
 cd cheerp-musl
 mkdir build_genericjs
 cd build_genericjs
-RANLIB="${CHEERP_DEST}/bin/llvm-ar s" AR="${CHEERP_DEST}/bin/llvm-ar"  CC="${CHEERP_DEST}/bin/clang -target cheerp" LD="${CHEERP_DEST}/bin/llvm-link" CFLAGS="-Wno-int-conversion" ../configure --target=cheerp --disable-shared --prefix=${CHEERP_DEST}
+RANLIB="${CHEERP_DEST}/bin/llvm-ar s" AR="${CHEERP_DEST}/bin/llvm-ar"  CC="${CHEERP_DEST}/bin/clang -target cheerp -I ${CHEERP_DEST}/lib/clang/15.0.0/include" LD="${CHEERP_DEST}/bin/llvm-link" CFLAGS="-Wno-int-conversion" ../configure --target=cheerp --disable-shared --prefix=${CHEERP_DEST} --with-malloc=dlmalloc
 make clean
 make -j8
 make install
 cd ..
 mkdir build_asmjs
 cd build_asmjs
-RANLIB="${CHEERP_DEST}/bin/llvm-ar s" AR="${CHEERP_DEST}/bin/llvm-ar"  CC="${CHEERP_DEST}/bin/clang -target cheerp-wasm" LD="${CHEERP_DEST}/bin/llvm-link" CFLAGS="-Wno-int-conversion" ../configure --target=cheerp-wasm --disable-shared --prefix=${CHEERP_DEST}
+RANLIB="${CHEERP_DEST}/bin/llvm-ar s" AR="${CHEERP_DEST}/bin/llvm-ar"  CC="${CHEERP_DEST}/bin/clang -target cheerp-wasm -I ${CHEERP_DEST}/lib/clang/15.0.0/include" LD="${CHEERP_DEST}/bin/llvm-link" CFLAGS="-Wno-int-conversion" ../configure --target=cheerp-wasm --disable-shared --prefix=${CHEERP_DEST} --with-malloc=dlmalloc
 make clean
 make -j8
 make install
@@ -136,14 +136,14 @@ cd ..
 cd cheerp-musl
 mkdir build_genericjs
 cd build_genericjs
-RANLIB="${CHEERP_DEST}/bin/llvm-ar s" AR="${CHEERP_DEST}/bin/llvm-ar"  CC="${CHEERP_DEST}/bin/clang -target cheerp -I ${CHEERP_DEST}/lib/clang/15.0.0/include" LD="${CHEERP_DEST}/bin/llvm-link" CPPFLAGS="" ../configure --target=cheerp --disable-shared --prefix=${CHEERP_DEST}
+RANLIB="${CHEERP_DEST}/bin/llvm-ar s" AR="${CHEERP_DEST}/bin/llvm-ar"  CC="${CHEERP_DEST}/bin/clang -target cheerp -I ${CHEERP_DEST}/lib/clang/15.0.0/include" LD="${CHEERP_DEST}/bin/llvm-link" CFLAGS="-Wno-int-conversion" ../configure --target=cheerp --disable-shared --prefix=${CHEERP_DEST} --with-malloc=dlmalloc
 make clean
 make -j8
 make install
 cd ..
 mkdir build_asmjs
 cd build_asmjs
-RANLIB="${CHEERP_DEST}/bin/llvm-ar s" AR="${CHEERP_DEST}/bin/llvm-ar"  CC="${CHEERP_DEST}/bin/clang -target cheerp-wasm -I ${CHEERP_DEST}/lib/clang/15.0.0/include" LD="${CHEERP_DEST}/bin/llvm-link" CPPFLAGS="" ../configure --target=cheerp-wasm --disable-shared --prefix=${CHEERP_DEST}
+RANLIB="${CHEERP_DEST}/bin/llvm-ar s" AR="${CHEERP_DEST}/bin/llvm-ar"  CC="${CHEERP_DEST}/bin/clang -target cheerp-wasm -I ${CHEERP_DEST}/lib/clang/15.0.0/include" LD="${CHEERP_DEST}/bin/llvm-link" CFLAGS="-Wno-int-conversion" ../configure --target=cheerp-wasm --disable-shared --prefix=${CHEERP_DEST} --with-malloc=dlmalloc
 make clean
 make -j8
 make install


### PR DESCRIPTION
The build instructions on the site do not work for musl, as it generates an error. Also, it doesn't compile with a malloc by default. Updated the build instructions to ignore the error `Wint-conversion` and also enable the malloc. I basically copied this from the readme at https://github.com/leaningtech/cheerp-musl